### PR TITLE
Add dependencies so npm can install them correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "ot-json0": "^1.1.0",
+    "uuid": "^8.3.0"
+  },
   "author": "yunluyl",
   "license": "MIT"
 }


### PR DESCRIPTION
Running JupyterLab gives a ModuleNotFoundError for 'uuid', which adding the dependencies should fix.